### PR TITLE
"Centralized" the export/definition of jsblocks.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -9,14 +9,29 @@
  * Date: @DATE
  */
 (function(global, factory) {
-  if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(global, true);
+  var blocks;
+  // handle jsblocks serverside rendering overrides
+  if (global.__mock__ && global._blocks) {
+    blocks = global._blocks;
   } else {
-    factory(global);
+    blocks = factory(global);
   }
 
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = blocks;
+  } else {
+    global.blocks = blocks;
+  }
+
+  if (typeof define === 'function' && define.amd) {
+    define('blocks', [], function () {
+      return blocks;
+    });
+  }
+
+
   // Pass this if window is not defined yet
-}(typeof window !== 'undefined' ? window : this, function(global, noGlobal) {
+}(typeof window !== 'undefined' ? window : this, function(global) {
   var toString = Object.prototype.toString;
   var slice = Array.prototype.slice;
   var hasOwn = Object.prototype.hasOwnProperty;
@@ -1080,16 +1095,6 @@
 
     return blocks;
   };
-
-  if (typeof define === 'function' && define.amd) {
-    define('blocks', [], function () {
-      return blocks;
-    });
-  }
-
-  if (noGlobal !== true) {
-    global.blocks = blocks;
-  }
 
   return blocks;
 


### PR DESCRIPTION
Added support for module loaders (e.g. bundled) in serverside rendering, blocks will now export the server defined jsblocks version.
Now servier side rendering works with bundled projects.
I'll link the PR that is adding the feature in jsblocks.